### PR TITLE
Switch to async API calls for those that support it.

### DIFF
--- a/Source/HTTPSession.swift
+++ b/Source/HTTPSession.swift
@@ -54,7 +54,7 @@ public class HTTPSession {
     /// Sets `power`, `color` or `brightness` (or any combination) over a `duration`, limited by `selector`.
     /// PUT /lights/{selector}/state
 	public func setLightsState(_ selector: String, power: Bool? = nil, color: String? = nil, brightness: Double? = nil, duration: Float, completionHandler: @escaping ((_ request: URLRequest, _ response: URLResponse?, _ results: [Result], _ error: Error?) -> Void)) {
-        let body = StateRequest(power: power?.asPower, color: color, brightness: brightness, duration: duration)
+        let body = StateRequest(power: power?.asPower, color: color, brightness: brightness, duration: duration, async: true)
         let request = HTTPRequest<StateRequest>(baseURL: baseURL, path: "lights/\(selector)/state", method: .put, headers: ["Content-Type": "application/json"], body: body, expectedStatusCodes: [200, 207])
         
         perform(request: request) { (response: HTTPResponse<Results>) in
@@ -84,7 +84,7 @@ public class HTTPSession {
     /// Activates a scene. The `duration` will override the duration stored on each scene device.
     /// PUT /scenes/{selector}/activate
 	public func setScenesActivate(_ selector: String, duration: Float? = nil, completionHandler: @escaping ((_ request: URLRequest, _ response: URLResponse?, _ results: [Result], _ error: Error?) -> Void)) {
-        let body = SceneRequest(duration: duration)
+        let body = SceneRequest(duration: duration, async: true)
         let request = HTTPRequest<SceneRequest>(baseURL: baseURL, path: "scenes/\(selector)/activate", method: .put, headers: ["Content-Type": "application/json"], body: body, expectedStatusCodes: [200, 207])
         
         perform(request: request) { (response: HTTPResponse<Results>) in

--- a/Source/LightTarget.swift
+++ b/Source/LightTarget.swift
@@ -275,7 +275,7 @@ public class LightTarget {
 			for result in results {
 				if result.id == light.id {
 					switch result.status {
-					case .OK:
+					case .OK, .Async:
                         return light.lightWithProperties(connected: true, inFlightProperties: newInFlightProperties, dirtyProperties: dirtyProperties)
 					case .TimedOut, .Offline:
                         // If failed, use new inFlight which removes the inFlight properties and use old dirtyProperties so that that property is not considered dirty

--- a/Source/Requests/SceneRequest.swift
+++ b/Source/Requests/SceneRequest.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct SceneRequest: Encodable {
     let duration: Float?
+    let async: Bool?
 }

--- a/Source/Requests/StateRequest.swift
+++ b/Source/Requests/StateRequest.swift
@@ -15,6 +15,7 @@ struct StateRequest: Encodable {
     let color: String?
     let brightness: Double?
     let duration: Float
+    let async: Bool?
 }
 
 extension Bool {

--- a/Source/Responses/Result.swift
+++ b/Source/Responses/Result.swift
@@ -12,6 +12,7 @@ public struct Results: Decodable {
 public struct Result: Decodable, Equatable, CustomStringConvertible {
 	public enum Status: String, Codable {
 		case OK       = "ok"
+		case Async    = "async"
 		case TimedOut = "timed_out"
 		case Offline  = "offline"
 	}


### PR DESCRIPTION
The async API is much faster, but has the downside that it does not indicate when the request times out - it can distinguish between offline and accepted for processing requests though.

We've recently switched the Google and Amazon integrations to this API.